### PR TITLE
Update Palladium.swift

### DIFF
--- a/Palladium/Core/Palladium.swift
+++ b/Palladium/Core/Palladium.swift
@@ -44,7 +44,7 @@ extension Palladium {
                 handler(Error.notAuthorized)
                 return
                 
-            case .notDetermined:
+            default:
                 break
             }
             


### PR DESCRIPTION
With swift latest version, switch cases must be exhaustive, so adding a default value fixes the compilation error